### PR TITLE
Move the source copying logic to a  file.

### DIFF
--- a/r-package/build_package.R
+++ b/r-package/build_package.R
@@ -4,17 +4,10 @@ library(testthat)
 
 package.name <- "gradient.forest"
 
-unlink("gradient.forest/src/*")
-bindings.files <- list.files("gradient.forest/bindings", recursive = TRUE, full.names = TRUE) 
-core.files <- list.files("../core", "\\.(h)|(cpp)$", recursive = TRUE, full.names = TRUE)
-file.copy(c(bindings.files, core.files), "gradient.forest/src")
-
 compileAttributes(package.name)
 
 clean_dll(package.name)
 build(package.name)
-
-#check(package.name)
 
 install(package.name)
 library(package.name, character.only = TRUE)

--- a/r-package/gradient.forest/configure
+++ b/r-package/gradient.forest/configure
@@ -1,0 +1,2 @@
+cp bindings/* src
+find ../../core/src/ \( -name ".h" -o -name ".cpp" \) -exec cp {} src \;


### PR DESCRIPTION
This should allow for installation through `dev_tools::install_github`.