### PR TITLE
Allow variance computations to use precomputed values.

### DIFF
--- a/core/src/forest/ForestPredictor.cpp
+++ b/core/src/forest/ForestPredictor.cpp
@@ -33,7 +33,7 @@ ForestPredictor::ForestPredictor(uint num_threads,
                                  uint ci_group_size,
                                  std::shared_ptr<OptimizedPredictionStrategy> strategy) {
   this->prediction_collector = std::shared_ptr<PredictionCollector>(
-      new OptimizedPredictionCollector(strategy));
+      new OptimizedPredictionCollector(strategy, ci_group_size));
   this->num_threads = num_threads == DEFAULT_NUM_THREADS
                       ? std::thread::hardware_concurrency()
                       : num_threads;

--- a/core/src/forest/ForestPredictor.cpp
+++ b/core/src/forest/ForestPredictor.cpp
@@ -40,13 +40,36 @@ ForestPredictor::ForestPredictor(uint num_threads,
 }
 
 std::vector<Prediction> ForestPredictor::predict(const Forest& forest, Data* data) {
-  std::vector<std::vector<size_t>> leaf_nodes_by_tree = find_leaf_nodes(forest, data, false);
-  return prediction_collector->collect_predictions(forest, data, leaf_nodes_by_tree, false);
+  return predict(forest, data, false);
 }
 
 std::vector<Prediction> ForestPredictor::predict_oob(const Forest& forest, Data* data) {
-  std::vector<std::vector<size_t>> leaf_nodes_by_tree = find_leaf_nodes(forest, data, true);
-  return prediction_collector->collect_predictions(forest, data, leaf_nodes_by_tree, true);
+  return predict(forest, data, true);
+}
+
+std::vector<Prediction> ForestPredictor::predict(const Forest& forest,
+                                                 Data* data,
+                                                 bool oob_prediction) {
+  std::vector<std::vector<size_t>> leaf_nodes_by_tree = find_leaf_nodes(forest, data, oob_prediction);
+  std::vector<std::vector<bool>> trees_by_sample = oob_prediction
+          ? get_trees_by_sample(forest, data)
+          : std::vector<std::vector<bool>>();
+  return prediction_collector->collect_predictions(forest, data, leaf_nodes_by_tree, trees_by_sample);
+}
+
+std::vector<std::vector<bool>> ForestPredictor::get_trees_by_sample(const Forest &forest,
+                                                                    Data *data) {
+  size_t num_trees = forest.get_trees().size();
+  size_t num_samples = data->get_num_rows();
+
+  std::vector<std::vector<bool>> result(num_samples, std::vector<bool>(num_trees));
+
+  for (size_t tree_idx = 0; tree_idx < num_trees; ++tree_idx) {
+    for (size_t sampleID : forest.get_trees()[tree_idx]->get_oob_sampleIDs()) {
+      result[sampleID][tree_idx] = true;
+    }
+  }
+  return result;
 }
 
 std::vector<std::vector<size_t>> ForestPredictor::find_leaf_nodes(

--- a/core/src/forest/ForestPredictor.h
+++ b/core/src/forest/ForestPredictor.h
@@ -46,6 +46,13 @@ public:
   std::vector<Prediction> predict_oob(const Forest& forest, Data* original_data);
 
 private:
+  std::vector<Prediction> predict(const Forest& forest,
+                                  Data* prediction_data,
+                                  bool oob_prediction);
+
+  std::vector<std::vector<bool>> get_trees_by_sample(const Forest &forest,
+                                                     Data *data);
+
   std::vector<std::vector<size_t>> find_leaf_nodes(
       const Forest &forest,
       Data *data,

--- a/core/src/prediction/CustomPredictionStrategy.cpp
+++ b/core/src/prediction/CustomPredictionStrategy.cpp
@@ -23,9 +23,8 @@ size_t CustomPredictionStrategy::prediction_length() {
   return 1;
 }
 
-Prediction CustomPredictionStrategy::predict(size_t sampleID,
-                                             const std::unordered_map<size_t, double>& weights_by_sampleID,
-                                             const Observations& observations) {
-  std::vector<double> prediction = { 0.0 };
-  return Prediction(prediction);
+std::vector<double> CustomPredictionStrategy::predict(size_t sampleID,
+    const std::unordered_map<size_t, double>& weights_by_sampleID,
+    const Observations& observations) {
+  return { 0.0 };
 }

--- a/core/src/prediction/CustomPredictionStrategy.h
+++ b/core/src/prediction/CustomPredictionStrategy.h
@@ -27,9 +27,9 @@ public:
   static const std::size_t OUTCOME;
 
   size_t prediction_length();
-  Prediction predict(size_t sampleID,
-                     const std::unordered_map<size_t, double>& weights_by_sampleID,
-                     const Observations& observations);
+  std::vector<double> predict(size_t sampleID,
+    const std::unordered_map<size_t, double>& weights_by_sampleID,
+    const Observations& observations);
 };
 
 

--- a/core/src/prediction/DefaultPredictionStrategy.h
+++ b/core/src/prediction/DefaultPredictionStrategy.h
@@ -29,9 +29,9 @@
 class DefaultPredictionStrategy {
 public:
   virtual size_t prediction_length() = 0;
-  virtual Prediction predict(size_t sampleID,
-                             const std::unordered_map<size_t, double>& weights_by_sampleID,
-                             const Observations& observations) = 0;
+  virtual std::vector<double> predict(size_t sampleID,
+      const std::unordered_map<size_t, double>& weights_by_sampleID,
+      const Observations& observations) = 0;
 };
 
 

--- a/core/src/prediction/InstrumentalPredictionStrategy.cpp
+++ b/core/src/prediction/InstrumentalPredictionStrategy.cpp
@@ -36,15 +36,14 @@ size_t InstrumentalPredictionStrategy::prediction_length() {
     return 1;
 }
 
-Prediction InstrumentalPredictionStrategy::predict(const std::vector<double>& average) {
+std::vector<double> InstrumentalPredictionStrategy::predict(const std::vector<double>& average) {
   double instrument_effect = average.at(OUTCOME_INSTRUMENT) - average.at(OUTCOME) * average.at(INSTRUMENT);
   double first_stage = average.at(TREATMENT_INSTRUMENT) - average.at(TREATMENT) * average.at(INSTRUMENT);
 
-  std::vector<double> prediction = { instrument_effect / first_stage };
-  return Prediction(prediction);
+  return { instrument_effect / first_stage };
 }
 
-Prediction InstrumentalPredictionStrategy::predict_with_variance(
+std::vector<double> InstrumentalPredictionStrategy::compute_variance(
     const std::vector<double>& average,
     const std::vector<std::vector<double>>& leaf_values,
     uint ci_group_size) {
@@ -135,10 +134,8 @@ Prediction InstrumentalPredictionStrategy::predict_with_variance(
     var_debiased = bayes_debiaser.debias(within_noise, num_good_groups, var_between);
   }
 
-  std::vector<double> predictions = { treatment_estimate };
   double variance_estimate = var_debiased / (first_stage * first_stage);
-  std::vector<double> variance_estimates = { variance_estimate };
-  return Prediction(predictions, variance_estimates);
+  return { variance_estimate };
 }
 
 PredictionValues InstrumentalPredictionStrategy::precompute_prediction_values(

--- a/core/src/prediction/InstrumentalPredictionStrategy.h
+++ b/core/src/prediction/InstrumentalPredictionStrategy.h
@@ -36,11 +36,11 @@ public:
   static const std::size_t TREATMENT_INSTRUMENT;
 
   size_t prediction_length();
-  Prediction predict(const std::vector<double>& average);
+  std::vector<double> predict(const std::vector<double>& average);
 
-  Prediction predict_with_variance(const std::vector<double>& average,
-                                   const std::vector<std::vector<double>>& leaf_values,
-                                   uint ci_group_size);
+  std::vector<double> compute_variance(const std::vector<double>& average,
+                          const std::vector<std::vector<double>>& leaf_values,
+                          uint ci_group_size);
 
   PredictionValues precompute_prediction_values(
       const std::vector<std::vector<size_t>>& leaf_sampleIDs,

--- a/core/src/prediction/InstrumentalPredictionStrategy.h
+++ b/core/src/prediction/InstrumentalPredictionStrategy.h
@@ -36,11 +36,10 @@ public:
   static const std::size_t TREATMENT_INSTRUMENT;
 
   size_t prediction_length();
-  Prediction predict(const std::vector<double>& averages);
+  Prediction predict(const std::vector<double>& average);
 
-  Prediction predict_with_variance(size_t sampleID,
-                                   const std::vector<std::vector<size_t>>& leaf_sampleIDs,
-                                   const Observations& observations,
+  Prediction predict_with_variance(const std::vector<double>& average,
+                                   const std::vector<std::vector<double>>& leaf_values,
                                    uint ci_group_size);
 
   PredictionValues precompute_prediction_values(

--- a/core/src/prediction/OptimizedPredictionStrategy.h
+++ b/core/src/prediction/OptimizedPredictionStrategy.h
@@ -31,10 +31,9 @@ public:
   virtual size_t prediction_length() = 0;
   virtual Prediction predict(const std::vector<double>& average_prediction_values) = 0;
 
-  virtual Prediction predict_with_variance(size_t sampleID,
-                                           const std::vector<std::vector<size_t>>& leaf_sampleIDs,
-                                           const Observations& observations,
-                                           uint ci_group_size) = 0;
+  virtual Prediction predict_with_variance(const std::vector<double>& average_prediction_values,
+      const std::vector<std::vector<double>>& leaf_prediction_values,
+      uint ci_group_size) = 0;
 
   virtual PredictionValues precompute_prediction_values(
       const std::vector<std::vector<size_t>>& leaf_sampleIDs,

--- a/core/src/prediction/OptimizedPredictionStrategy.h
+++ b/core/src/prediction/OptimizedPredictionStrategy.h
@@ -29,9 +29,9 @@
 class OptimizedPredictionStrategy {
 public:
   virtual size_t prediction_length() = 0;
-  virtual Prediction predict(const std::vector<double>& average_prediction_values) = 0;
+  virtual std::vector<double> predict(const std::vector<double>& average_prediction_values) = 0;
 
-  virtual Prediction predict_with_variance(const std::vector<double>& average_prediction_values,
+  virtual std::vector<double> compute_variance(const std::vector<double>& average_prediction_values,
       const std::vector<std::vector<double>>& leaf_prediction_values,
       uint ci_group_size) = 0;
 

--- a/core/src/prediction/PredictionValues.cpp
+++ b/core/src/prediction/PredictionValues.cpp
@@ -36,4 +36,6 @@ double PredictionValues::get(std::size_t node, size_t type) const {
   return values.at(node).at(type);
 }
 
-
+const std::vector<double>& PredictionValues::get_values(std::size_t node) const {
+  return values.at(node);
+}

--- a/core/src/prediction/PredictionValues.h
+++ b/core/src/prediction/PredictionValues.h
@@ -35,16 +35,14 @@ public:
 
   double get(size_t node, size_t type) const;
 
+  const std::vector<double>& get_values(size_t nodeID) const;
+
   const size_t get_num_nodes() const {
     return num_nodes;
   }
 
   const size_t get_num_types() const {
     return num_types;
-  }
-
-  const std::vector<std::vector<double>>& get_values() const {
-    return values;
   }
 
 private:

--- a/core/src/prediction/QuantilePredictionStrategy.cpp
+++ b/core/src/prediction/QuantilePredictionStrategy.cpp
@@ -30,9 +30,9 @@ size_t QuantilePredictionStrategy::prediction_length() {
     return quantiles.size();
 }
 
-Prediction QuantilePredictionStrategy::predict(size_t sampleID,
-                                               const std::unordered_map<size_t, double>& weights_by_sampleID,
-                                               const Observations& observations) {
+std::vector<double> QuantilePredictionStrategy::predict(size_t sampleID,
+    const std::unordered_map<size_t, double>& weights_by_sampleID,
+    const Observations& observations) {
   std::vector<std::pair<size_t, double>> sampleIDs_and_values;
   for (auto it = weights_by_sampleID.begin(); it != weights_by_sampleID.end(); ++it) {
     size_t sampleID = it->first;
@@ -40,8 +40,7 @@ Prediction QuantilePredictionStrategy::predict(size_t sampleID,
         sampleID, observations.get(Observations::OUTCOME, sampleID)));
   }
 
-  std::vector<double> quantile_cutoffs = compute_quantile_cutoffs(weights_by_sampleID, sampleIDs_and_values);
-  return Prediction(quantile_cutoffs);
+  return compute_quantile_cutoffs(weights_by_sampleID, sampleIDs_and_values);
 }
 
 std::vector<double> QuantilePredictionStrategy::compute_quantile_cutoffs(

--- a/core/src/prediction/QuantilePredictionStrategy.h
+++ b/core/src/prediction/QuantilePredictionStrategy.h
@@ -30,9 +30,9 @@ public:
   QuantilePredictionStrategy(std::vector<double> quantiles);
 
   size_t prediction_length();
-  Prediction predict(size_t sampleID,
-                     const std::unordered_map<size_t, double>& weights_by_sampleID,
-                     const Observations& observations);
+  std::vector<double> predict(size_t sampleID,
+    const std::unordered_map<size_t, double>& weights_by_sampleID,
+    const Observations& observations);
 
 private:
   std::vector<double> compute_quantile_cutoffs(const std::unordered_map<size_t, double>& weights_by_sampleID,

--- a/core/src/prediction/RegressionPredictionStrategy.cpp
+++ b/core/src/prediction/RegressionPredictionStrategy.cpp
@@ -25,12 +25,11 @@ size_t RegressionPredictionStrategy::prediction_length() {
     return 1;
 }
 
-Prediction RegressionPredictionStrategy::predict(const std::vector<double>& average) {
-  std::vector<double> predictions = { average.at(OUTCOME) };
-  return Prediction(predictions);
+std::vector<double> RegressionPredictionStrategy::predict(const std::vector<double>& average) {
+  return { average.at(OUTCOME) };
 }
 
-Prediction RegressionPredictionStrategy::predict_with_variance(
+std::vector<double> RegressionPredictionStrategy::compute_variance(
     const std::vector<double>& average,
     const std::vector<std::vector<double>>& leaf_values,
     uint ci_group_size) {

--- a/core/src/prediction/RegressionPredictionStrategy.cpp
+++ b/core/src/prediction/RegressionPredictionStrategy.cpp
@@ -25,15 +25,14 @@ size_t RegressionPredictionStrategy::prediction_length() {
     return 1;
 }
 
-Prediction RegressionPredictionStrategy::predict(const std::vector<double>& averages) {
-  std::vector<double> predictions = { averages.at(OUTCOME) };
+Prediction RegressionPredictionStrategy::predict(const std::vector<double>& average) {
+  std::vector<double> predictions = { average.at(OUTCOME) };
   return Prediction(predictions);
 }
 
 Prediction RegressionPredictionStrategy::predict_with_variance(
-    size_t sampleID,
-    const std::vector<std::vector<size_t>>& leaf_sampleIDs,
-    const Observations& observations,
+    const std::vector<double>& average,
+    const std::vector<std::vector<double>>& leaf_values,
     uint ci_group_size) {
   throw std::runtime_error("Variance estimates are not yet implemented.");
 }

--- a/core/src/prediction/RegressionPredictionStrategy.h
+++ b/core/src/prediction/RegressionPredictionStrategy.h
@@ -27,12 +27,11 @@ class RegressionPredictionStrategy: public OptimizedPredictionStrategy {
 public:
   size_t prediction_length();
 
-  Prediction predict(const std::vector<double>& averages);
+  Prediction predict(const std::vector<double>& average);
 
   Prediction predict_with_variance(
-      size_t sampleID,
-      const std::vector<std::vector<size_t>>& leaf_sampleIDs,
-      const Observations& observations,
+      const std::vector<double>& average,
+      const std::vector<std::vector<double>>& leaf_values,
       uint ci_group_size);
 
   PredictionValues precompute_prediction_values(const std::vector<std::vector<size_t>>& leaf_sampleIDs,

--- a/core/src/prediction/RegressionPredictionStrategy.h
+++ b/core/src/prediction/RegressionPredictionStrategy.h
@@ -27,9 +27,9 @@ class RegressionPredictionStrategy: public OptimizedPredictionStrategy {
 public:
   size_t prediction_length();
 
-  Prediction predict(const std::vector<double>& average);
+  std::vector<double> predict(const std::vector<double>& average);
 
-  Prediction predict_with_variance(
+  std::vector<double> compute_variance(
       const std::vector<double>& average,
       const std::vector<std::vector<double>>& leaf_values,
       uint ci_group_size);

--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -34,7 +34,7 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
     std::unordered_map<size_t, double> weights_by_sampleID;
 
     // Create a list of weighted neighbors for this sample.
-    uint num_nonempty_leaves = 0;
+    uint num_leaves = 0;
     for (size_t tree_index = 0; tree_index < forest.get_trees().size(); ++tree_index) {
       if (!trees_by_sample.empty() && !trees_by_sample[sampleID][tree_index]) {
         continue;
@@ -46,14 +46,14 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
       size_t nodeID = leaf_node_IDs.at(sampleID);
       const std::vector<size_t> &sampleIDs = tree->get_leaf_nodeIDs()[nodeID];
       if (!sampleIDs.empty()) {
-        num_nonempty_leaves++;
+        num_leaves++;
         add_sample_weights(sampleIDs, weights_by_sampleID);
       }
     }
 
     // If this sample has no neighbors, then return placeholder predictions. Note
     // that this can only occur when honesty is enabled, and is expected to be rare.
-    if (num_nonempty_leaves == 0) {
+    if (num_leaves == 0) {
       std::vector<double> temp(prediction_strategy->prediction_length(), NAN);
       predictions.push_back(temp);
       continue;

--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -24,32 +24,19 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
     const Forest& forest,
     Data* prediction_data,
     std::vector<std::vector<size_t>> leaf_nodes_by_tree,
-    bool oob_prediction) {
+    std::vector<std::vector<bool>> trees_by_sample) {
 
   size_t num_samples = prediction_data->get_num_rows();
-  size_t num_trees = forest.get_trees().size();
-
-  std::vector<std::vector<bool>> trees_by_samples(num_samples, std::vector<bool>(num_trees));
-  if (oob_prediction) {
-    for (size_t tree_idx = 0; tree_idx < num_trees; ++tree_idx) {
-      for (size_t sampleID : forest.get_trees()[tree_idx]->get_oob_sampleIDs()) {
-        trees_by_samples[sampleID][tree_idx] = true;
-      }
-    }
-  }
-
   std::vector<Prediction> predictions;
   predictions.reserve(num_samples);
-  size_t prediction_length = prediction_strategy->prediction_length();
 
   for (size_t sampleID = 0; sampleID < num_samples; ++sampleID) {
     std::unordered_map<size_t, double> weights_by_sampleID;
 
-
     // Create a list of weighted neighbors for this sample.
     uint num_nonempty_leaves = 0;
-    for (size_t tree_index = 0; tree_index < num_trees; ++tree_index) {
-      if (oob_prediction && !trees_by_samples[sampleID][tree_index]) {
+    for (size_t tree_index = 0; tree_index < forest.get_trees().size(); ++tree_index) {
+      if (!trees_by_sample.empty() && !trees_by_sample[sampleID][tree_index]) {
         continue;
       }
 
@@ -64,10 +51,10 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
       }
     }
 
+    // If this sample has no neighbors, then return placeholder predictions. Note
+    // that this can only occur when honesty is enabled, and is expected to be rare.
     if (num_nonempty_leaves == 0) {
-      // If this sample has no neighbors, then return placeholder predictions. Note
-      // that this can only occur when honesty is enabled, and is expected to be rare.
-      std::vector<double> temp(prediction_length, NAN);
+      std::vector<double> temp(prediction_strategy->prediction_length(), NAN);
       predictions.push_back(temp);
       continue;
     }
@@ -76,10 +63,8 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
 
     Prediction prediction = prediction_strategy->predict(
         sampleID, weights_by_sampleID, forest.get_observations());
-    if (prediction.size() != prediction_length) {
-      throw std::runtime_error("Prediction for sample " + std::to_string(sampleID) +
-                               " did not have the expected length.");
-    }
+
+    validate_prediction(sampleID, prediction);
     predictions.push_back(prediction);
   }
   return predictions;
@@ -102,5 +87,13 @@ void DefaultPredictionCollector::normalize_sample_weights(std::unordered_map<siz
 
   for (auto it = weights_by_sampleID.begin(); it != weights_by_sampleID.end(); ++it) {
     it->second /= total_weight;
+  }
+}
+
+void DefaultPredictionCollector::validate_prediction(size_t sampleID, Prediction prediction) {
+  size_t prediction_length = prediction_strategy->prediction_length();
+  if (prediction.size() != prediction_length) {
+    throw std::runtime_error("Prediction for sample " + std::to_string(sampleID) +
+                             " did not have the expected length.");
   }
 }

--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -17,8 +17,8 @@
 
 #include "prediction/collector/DefaultPredictionCollector.h"
 
-DefaultPredictionCollector::DefaultPredictionCollector(std::shared_ptr<DefaultPredictionStrategy> prediction_strategy):
-    prediction_strategy(prediction_strategy) {}
+DefaultPredictionCollector::DefaultPredictionCollector(std::shared_ptr<DefaultPredictionStrategy> strategy):
+    strategy(strategy) {}
 
 std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
     const Forest& forest,
@@ -54,14 +54,14 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
     // If this sample has no neighbors, then return placeholder predictions. Note
     // that this can only occur when honesty is enabled, and is expected to be rare.
     if (num_leaves == 0) {
-      std::vector<double> temp(prediction_strategy->prediction_length(), NAN);
+      std::vector<double> temp(strategy->prediction_length(), NAN);
       predictions.push_back(temp);
       continue;
     }
 
     normalize_sample_weights(weights_by_sampleID);
 
-    Prediction prediction = prediction_strategy->predict(
+    Prediction prediction = strategy->predict(
         sampleID, weights_by_sampleID, forest.get_observations());
 
     validate_prediction(sampleID, prediction);
@@ -91,7 +91,7 @@ void DefaultPredictionCollector::normalize_sample_weights(std::unordered_map<siz
 }
 
 void DefaultPredictionCollector::validate_prediction(size_t sampleID, Prediction prediction) {
-  size_t prediction_length = prediction_strategy->prediction_length();
+  size_t prediction_length = strategy->prediction_length();
   if (prediction.size() != prediction_length) {
     throw std::runtime_error("Prediction for sample " + std::to_string(sampleID) +
                              " did not have the expected length.");

--- a/core/src/prediction/collector/DefaultPredictionCollector.h
+++ b/core/src/prediction/collector/DefaultPredictionCollector.h
@@ -25,7 +25,7 @@
 
 class DefaultPredictionCollector: public PredictionCollector {
 public:
-  DefaultPredictionCollector(std::shared_ptr<DefaultPredictionStrategy> prediction_strategy);
+  DefaultPredictionCollector(std::shared_ptr<DefaultPredictionStrategy> strategy);
 
   std::vector<Prediction> collect_predictions(const Forest &forest,
                                               Data *prediction_data,
@@ -38,7 +38,7 @@ private:
   void normalize_sample_weights(std::unordered_map<size_t, double>& weights_by_sampleID);
   void validate_prediction(size_t sampleID, Prediction prediction);
 
-  std::shared_ptr<DefaultPredictionStrategy> prediction_strategy;
+  std::shared_ptr<DefaultPredictionStrategy> strategy;
 };
 
 

--- a/core/src/prediction/collector/DefaultPredictionCollector.h
+++ b/core/src/prediction/collector/DefaultPredictionCollector.h
@@ -30,12 +30,13 @@ public:
   std::vector<Prediction> collect_predictions(const Forest &forest,
                                               Data *prediction_data,
                                               std::vector<std::vector<size_t>> leaf_nodes_by_tree,
-                                              bool oob_prediction);
+                                              std::vector<std::vector<bool>> trees_by_sample);
 private:
   void add_sample_weights(const std::vector<size_t>& sampleIDs,
                           std::unordered_map<size_t, double>& weights_by_sampleID);
 
   void normalize_sample_weights(std::unordered_map<size_t, double>& weights_by_sampleID);
+  void validate_prediction(size_t sampleID, Prediction prediction);
 
   std::shared_ptr<DefaultPredictionStrategy> prediction_strategy;
 };

--- a/core/src/prediction/collector/OptimizedPredictionCollector.cpp
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.cpp
@@ -23,9 +23,10 @@ OptimizedPredictionCollector::OptimizedPredictionCollector(std::shared_ptr<Optim
 std::vector<Prediction> OptimizedPredictionCollector::collect_predictions(const Forest &forest,
                                                                           Data *prediction_data,
                                                                           std::vector<std::vector<size_t>> leaf_nodes_by_tree,
-                                                                          bool oob_prediction) {
+                                                                          std::vector<std::vector<bool>> trees_by_sample) {
   size_t num_trees = forest.get_trees().size();
   size_t num_predictions = prediction_data->get_num_rows();
+  bool oob_prediction = !trees_by_sample.empty();
 
   // Collect the average prediction values across trees.
   std::vector<std::vector<double>> average_prediction_values(num_predictions);

--- a/core/src/prediction/collector/OptimizedPredictionCollector.cpp
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.cpp
@@ -71,10 +71,13 @@ std::vector<Prediction> OptimizedPredictionCollector::collect_predictions(const 
 
     normalize_prediction_values(num_leaves, average_value);
 
-    Prediction prediction = ci_group_size == 1
-            ? strategy->predict(average_value)
-            : strategy->predict_with_variance(average_value, leaf_values, ci_group_size);
+    std::vector<double> point_prediction = strategy->predict(average_value);
+    std::vector<double> variance_estimate;
+    if (ci_group_size > 1) {
+      variance_estimate = strategy->compute_variance(average_value, leaf_values, ci_group_size);
+    }
 
+    Prediction prediction(point_prediction, variance_estimate);
     validate_prediction(sampleID, prediction);
     predictions.push_back(prediction);
   }

--- a/core/src/prediction/collector/OptimizedPredictionCollector.cpp
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.cpp
@@ -24,68 +24,74 @@ std::vector<Prediction> OptimizedPredictionCollector::collect_predictions(const 
                                                                           Data *prediction_data,
                                                                           std::vector<std::vector<size_t>> leaf_nodes_by_tree,
                                                                           std::vector<std::vector<bool>> trees_by_sample) {
-  size_t num_trees = forest.get_trees().size();
-  size_t num_predictions = prediction_data->get_num_rows();
-  bool oob_prediction = !trees_by_sample.empty();
+  size_t num_samples = prediction_data->get_num_rows();
+  std::vector<Prediction> predictions;
+  predictions.reserve(num_samples);
 
-  // Collect the average prediction values across trees.
-  std::vector<std::vector<double>> average_prediction_values(num_predictions);
-  std::vector<size_t> num_nonempty_leaves(num_predictions);
+  for (size_t sampleID = 0; sampleID < num_samples; ++sampleID) {
+    std::vector<double> combined_average;
+    std::vector<std::vector<double>> leaf_averages;
 
-  for (size_t tree_index = 0; tree_index < num_trees; ++tree_index) {
-    std::shared_ptr<Tree> tree = forest.get_trees()[tree_index];
-    const PredictionValues &prediction_values = tree->get_prediction_values();
-    const std::vector<size_t>& leaf_nodes = leaf_nodes_by_tree.at(tree_index);
+    // Create a list of weighted neighbors for this sample.
+    uint num_leaves = 0;
+    for (size_t tree_index = 0; tree_index < forest.get_trees().size(); ++tree_index) {
+      if (!trees_by_sample.empty() && !trees_by_sample[sampleID][tree_index]) {
+        continue;
+      }
 
-    size_t num_samples = oob_prediction ? tree->get_oob_sampleIDs().size() : num_predictions;
-    for (size_t i = 0; i < num_samples; ++i) {
-      size_t sampleID = oob_prediction ? tree->get_oob_sampleIDs()[i] : i;
-      size_t nodeID = leaf_nodes.at(sampleID);
+      const std::vector<size_t>& leaf_node_IDs = leaf_nodes_by_tree.at(tree_index);
+      size_t nodeID = leaf_node_IDs.at(sampleID);
+
+      std::shared_ptr<Tree> tree = forest.get_trees()[tree_index];
+      const PredictionValues& prediction_values = tree->get_prediction_values();
 
       if (!prediction_values.empty(nodeID)) {
-        add_prediction_values(nodeID, prediction_values, average_prediction_values[sampleID]);
-        num_nonempty_leaves[sampleID]++;
+        num_leaves++;
+        add_prediction_values(nodeID, prediction_values, combined_average);
       }
     }
-  }
 
-  // Normalize the prediction values, and make a prediction for each sample.
-  std::vector<Prediction> predictions;
-  predictions.reserve(num_predictions);
-  size_t prediction_length = prediction_strategy->prediction_length();
-
-  for (size_t sampleID = 0; sampleID < prediction_data->get_num_rows(); ++sampleID) {
-    size_t num_leaves = num_nonempty_leaves[sampleID];
-
+    // If this sample has no neighbors, then return placeholder predictions. Note
+    // that this can only occur when honesty is enabled, and is expected to be rare.
     if (num_leaves == 0) {
-      // If this sample has no neighbors, then return placeholder predictions. Note
-      // that this can only occur when honesty is enabled, and is expected to be rare.
-      std::vector<double> temp(prediction_length, NAN);
-      predictions.push_back(Prediction(temp));
-    } else {
-      std::vector<double> &average_prediction_value = average_prediction_values[sampleID];
-      normalize_prediction_values(num_leaves, average_prediction_value);
-      predictions.push_back(prediction_strategy->predict(average_prediction_value));
+      std::vector<double> temp(prediction_strategy->prediction_length(), NAN);
+      predictions.push_back(temp);
+      continue;
     }
+
+    normalize_prediction_values(num_leaves, combined_average);
+
+    Prediction prediction = prediction_strategy->predict(combined_average);
+
+    validate_prediction(sampleID, prediction);
+    predictions.push_back(prediction);
   }
   return predictions;
 }
 
 void OptimizedPredictionCollector::add_prediction_values(size_t nodeID,
-                                              const PredictionValues& prediction_values,
-                                              std::vector<double>& average_prediction_values) {
-  if (average_prediction_values.empty()) {
-    average_prediction_values.resize(prediction_values.get_num_types());
+    const PredictionValues& prediction_values,
+    std::vector<double>& combined_average) {
+  if (combined_average.empty()) {
+    combined_average.resize(prediction_values.get_num_types());
   }
 
   for (size_t type = 0; type < prediction_values.get_num_types(); ++type) {
-    average_prediction_values[type] += prediction_values.get(nodeID, type);
+    combined_average[type] += prediction_values.get(nodeID, type);
   }
 }
 
-void OptimizedPredictionCollector::normalize_prediction_values(size_t num_leaf_nodes,
-                                                    std::vector<double>& average_prediction_values) {
-  for (double& value : average_prediction_values) {
-    value /= num_leaf_nodes;
+void OptimizedPredictionCollector::normalize_prediction_values(size_t num_leaves,
+    std::vector<double>& combined_average) {
+  for (double& value : combined_average) {
+    value /= num_leaves;
+  }
+}
+
+void OptimizedPredictionCollector::validate_prediction(size_t sampleID, Prediction prediction) {
+  size_t prediction_length = prediction_strategy->prediction_length();
+  if (prediction.size() != prediction_length) {
+    throw std::runtime_error("Prediction for sample " + std::to_string(sampleID) +
+                             " did not have the expected length.");
   }
 }

--- a/core/src/prediction/collector/OptimizedPredictionCollector.h
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.h
@@ -34,10 +34,12 @@ public:
 private:
   void add_prediction_values(size_t nodeID,
                              const PredictionValues& prediction_values,
-                             std::vector<double>& average_prediction_values);
+                             std::vector<double>& combined_average);
 
-  void normalize_prediction_values(size_t num_leaf_nodes,
-                                   std::vector<double>& average_prediction_values);
+  void normalize_prediction_values(size_t num_leaves,
+                                   std::vector<double>& combined_average);
+
+  void validate_prediction(size_t sampleID, Prediction prediction);
 
   std::shared_ptr<OptimizedPredictionStrategy> prediction_strategy;
 };

--- a/core/src/prediction/collector/OptimizedPredictionCollector.h
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.h
@@ -29,7 +29,7 @@ public:
   std::vector<Prediction> collect_predictions(const Forest &forest,
                                               Data *prediction_data,
                                               std::vector<std::vector<size_t>> leaf_nodes_by_tree,
-                                              bool oob_prediction);
+                                              std::vector<std::vector<bool>> trees_by_sample);
 
 private:
   void add_prediction_values(size_t nodeID,

--- a/core/src/prediction/collector/OptimizedPredictionCollector.h
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.h
@@ -24,7 +24,8 @@
 
 class OptimizedPredictionCollector: public PredictionCollector {
 public:
-  OptimizedPredictionCollector(std::shared_ptr<OptimizedPredictionStrategy> prediction_strategy);
+  OptimizedPredictionCollector(std::shared_ptr<OptimizedPredictionStrategy> strategy,
+                               uint ci_group_size);
 
   std::vector<Prediction> collect_predictions(const Forest &forest,
                                               Data *prediction_data,
@@ -41,7 +42,8 @@ private:
 
   void validate_prediction(size_t sampleID, Prediction prediction);
 
-  std::shared_ptr<OptimizedPredictionStrategy> prediction_strategy;
+  std::shared_ptr<OptimizedPredictionStrategy> strategy;
+  uint ci_group_size;
 };
 
 

--- a/core/src/prediction/collector/PredictionCollector.h
+++ b/core/src/prediction/collector/PredictionCollector.h
@@ -24,8 +24,8 @@ class PredictionCollector {
 public:
   virtual std::vector<Prediction> collect_predictions(const Forest& forest,
                                                       Data* prediction_data,
-                                                      std::vector <std::vector<size_t>> leaf_nodes_by_tree,
-                                                      bool oob_prediction) = 0;
+                                                      std::vector<std::vector<size_t>> leaf_nodes_by_tree,
+                                                      std::vector<std::vector<bool>> trees_by_sample) = 0;
 };
 
 #endif //GRADIENTFOREST_PREDICTIONCOLLECTOR_H

--- a/core/src/serialization/PredictionValuesSerializer.cpp
+++ b/core/src/serialization/PredictionValuesSerializer.cpp
@@ -25,9 +25,9 @@ void PredictionValuesSerializer::serialize(std::ostream& stream, const Predictio
   size_t num_types = prediction_values.get_num_types();
   stream.write((char*) &num_types, sizeof(num_types));
 
-  auto values = prediction_values.get_values();
-  for (auto& value : values) {
-    write_vector(value, stream);
+  for (size_t node = 0; node < num_nodes; node++) {
+    const std::vector<double>& values = prediction_values.get_values(node);
+    write_vector(values, stream);
   }
 }
 

--- a/core/test/prediction/QuantilePredictionStrategyTest.cpp
+++ b/core/test/prediction/QuantilePredictionStrategyTest.cpp
@@ -69,14 +69,11 @@ TEST_CASE("prediction with repeated quantiles", "[quantile, prediction]") {
   Observations observations = TestUtilities::create_observations(original_outcomes);
 
   std::vector<double> first_predictions = QuantilePredictionStrategy({0.5})
-          .predict(42, weights_by_sampleID, observations)
-          .get_predictions();
+          .predict(42, weights_by_sampleID, observations);
   std::vector<double> second_predictions = QuantilePredictionStrategy({0.25, 0.5, 0.75})
-      .predict(42, weights_by_sampleID, observations)
-      .get_predictions();
+      .predict(42, weights_by_sampleID, observations);
   std::vector<double> third_predictions = QuantilePredictionStrategy({0.5, 0.5, 0.5})
-      .predict(42, weights_by_sampleID, observations)
-      .get_predictions();
+      .predict(42, weights_by_sampleID, observations);
 
   REQUIRE(first_predictions[0] == second_predictions[1]);
   for (auto prediction : third_predictions) {

--- a/core/test/serialization/SerializationTest.cpp
+++ b/core/test/serialization/SerializationTest.cpp
@@ -55,7 +55,7 @@ TEST_CASE("trees serialize and deserialize correctly", "[treeSerialization]") {
       {10, 20, 30, 40},
       {0.5, 0.75, 0.9, 1.1, 1.2},
       {3, 4, 5, 9, 10, 11},
-      PredictionValues({{0, 0, 1}}, 3, 1)));
+      PredictionValues({{0, 0, 1}}, 1, 3)));
 
   TreeSerializer tree_serializer;
   std::stringstream stream;


### PR DESCRIPTION
* Pull the creation of the in-bag trees matrix into ForestPredictor.
* Restructure optimized prediction to match the default strategy.
* Collect leaf prediction values during optimized prediction.
* Use precomputed values in instrumental variance calculation.